### PR TITLE
Make the window transparent (32-bit color depth)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .zigx = .{
-            .url = "https://github.com/MadLittleMods/zigx/archive/82fb1b754261dd683f16f8cffeabf41c3fc312a8.tar.gz",
-            .hash = "12204177402d59ffbb41a7cb32782880140d24da16e413799fa498e7c6a6d5847218",
+            .url = "https://github.com/MadLittleMods/zigx/archive/ad97e8925f897a6e6cd36f42532d5a0a104d0278.tar.gz",
+            .hash = "12203605dbc064c7c1bbbf3bb98d2521ca8d059d86a75b44eb2fefac469e1d8b6e68",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .zigx = .{
-            .url = "https://github.com/marler8997/zigx/archive/454432fd1ad0ae0f1a949b6f1828cffcce3bb4ce.tar.gz",
-            .hash = "1220a6ba0703e5baab2c5eb18931c66e4a73b59a298c24ed03f588c80e7c3f82a2ea",
+            .url = "https://github.com/MadLittleMods/zigx/archive/82fb1b754261dd683f16f8cffeabf41c3fc312a8.tar.gz",
+            .hash = "12204177402d59ffbb41a7cb32782880140d24da16e413799fa498e7c6a6d5847218",
         },
     },
 }

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -66,6 +66,36 @@ Determine the color depth of your window or the root window ([via StackOverflow]
 ## Testing with multiple screens
 
 Add a virtual monitor ([*courtesy of this GitHub issue*](https://github.com/pavlobu/deskreen/issues/42#issue-792962894)):
+
+List available ports:
+```sh
+$ xrandr
+Screen 0: minimum 320 x 200, current 3840 x 2160, maximum 16384 x 16384
+DisplayPort-0 connected 3840x2160+0+0 (normal left inverted right x axis y axis) 878mm x 485mm
+   3840x2160     60.00*+  30.00    30.00
+   2560x1440     59.95
+   1920x1200     60.00
+   1920x1080     60.00    60.00    50.00    50.00    59.94
+   1600x1200     60.00
+   1680x1050     59.95
+   1280x1024     75.02    60.02
+   1440x900      74.98    59.89
+   1280x960      60.00
+   1280x800      60.00
+   1280x720      60.00    50.00    59.94
+   1024x768      75.03    60.00
+   800x600       75.00    60.32
+   720x576       50.00
+   720x480       60.00    59.94
+   640x480       75.00    72.81    66.67    60.00    59.94
+   720x400       70.08
+DisplayPort-1 disconnected (normal left inverted right x axis y axis)
+DisplayPort-2 disconnected (normal left inverted right x axis y axis)
+HDMI-A-0 disconnected (normal left inverted right x axis y axis)
+   1920x1080     60.00
+```
+
+Add a virtual monitor:
 ```
 xrandr --addmode HDMI-A-0 1920x1080
 xrandr --output HDMI-A-0 --mode 1920x1080 --right-of DisplayPort-0
@@ -75,3 +105,12 @@ To disconnect the display:
 ```
 xrandr --output HDMI-A-0 --off
 ```
+
+List monitors:
+```
+xrandr --listmonitors
+```
+
+Other resources:
+
+ - https://www.youtube.com/watch?v=N9KxpPyJMJA

--- a/dev-notes.md
+++ b/dev-notes.md
@@ -65,7 +65,10 @@ Determine the color depth of your window or the root window ([via StackOverflow]
 
 ## Testing with multiple screens
 
-Add a virtual monitor ([*courtesy of this GitHub issue*](https://github.com/pavlobu/deskreen/issues/42#issue-792962894)):
+> [!WARNING]  
+> These steps don't actually seem to work to add another "screen" in terms of what the X Window Server sees. But still seem like useful commands to keep around until I do figure out how this all works.
+
+Add a virtual monitor ([*courtesy of this GitHub issue*](https://github.com/pavlobu/deskreen/issues/42#issue-792962894)).
 
 List available ports:
 ```sh

--- a/src/main.zig
+++ b/src/main.zig
@@ -108,7 +108,7 @@ pub fn main() !u8 {
             // suggestion whether the window manager to decorate this window (false) or
             // we want to override the behavior. We set this to true to disable the
             // window controls (basically a borderless window).
-            // .override_redirect = true,
+            .override_redirect = true,
             //            .save_under = true,
             .event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,
             //                | x.event.pointer_motion_hint WHAT THIS DO?

--- a/src/main.zig
+++ b/src/main.zig
@@ -51,7 +51,7 @@ pub fn main() !u8 {
         }
         break :blk screen;
     };
-    
+
     const depth = 32;
     const matching_visual_type = try screen.findMatchingVisualType(depth, .true_color, allocator);
     std.log.debug("matching_visual_type {any}", .{matching_visual_type});
@@ -65,7 +65,7 @@ pub fn main() !u8 {
         var message_buffer: [x.create_colormap.len]u8 = undefined;
         x.create_colormap.serialize(&message_buffer, .{
             .id = ids.colormap(),
-            .window_id = screen.root,//window_id,
+            .window_id = screen.root, //window_id,
             .visual_id = matching_visual_type.id,
             .alloc = .none,
         });
@@ -224,6 +224,10 @@ pub fn main() !u8 {
                 },
                 .reply => |msg| {
                     std.log.info("todo: handle a reply message {}", .{msg});
+                    return error.TodoHandleReplyMessage;
+                },
+                .ge_generic => |msg| {
+                    std.log.info("todo: handle a GE generic event {}", .{msg});
                     return error.TodoHandleReplyMessage;
                 },
                 .key_press => |msg| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -94,7 +94,7 @@ pub fn main() !u8 {
         }, .{
             .bg_pixmap = .none,
             // 0xAARRGGBB
-            .bg_pixel = 0x00000000,
+            .bg_pixel = 0xaa006660,
             //            //.border_pixmap =
             .border_pixel = 0x00000000,
             .colormap = @enumFromInt(ids.colormap()),
@@ -108,7 +108,7 @@ pub fn main() !u8 {
             // suggestion whether the window manager to decorate this window (false) or
             // we want to override the behavior. We set this to true to disable the
             // window controls (basically a borderless window).
-            .override_redirect = true,
+            // .override_redirect = true,
             //            .save_under = true,
             .event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,
             //                | x.event.pointer_motion_hint WHAT THIS DO?
@@ -132,8 +132,8 @@ pub fn main() !u8 {
             .gc_id = background_graphics_context_id,
             .drawable_id = window_id,
         }, .{
-            .background = 0x0000ff00,
-            .foreground = 0x000000ff,
+            .background = 0xff00ff00,
+            .foreground = 0xff0000ff,
         });
         try conn.send(message_buffer[0..len]);
     }
@@ -145,8 +145,8 @@ pub fn main() !u8 {
             .gc_id = foreground_graphics_context_id,
             .drawable_id = window_id,
         }, .{
-            .background = screen.black_pixel,
-            .foreground = 0x00ffff00,
+            .background = 0xff000000,
+            .foreground = 0xffffff00,
         });
         try conn.send(message_buffer[0..len]);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,9 +61,7 @@ pub fn main() !u8 {
     const ids = Ids{ .base = conn.setup.fixed().resource_id_base };
     const window_id = ids.window();
     std.log.info("window_id {0} 0x{0x}", .{window_id});
-    //std.log.info("screen.root_visual visual_id {0} 0x{0x}", .{screen.root_visual});
     {
-    std.log.info("creating colormap {0} 0x{0x}", .{ids.colormap()});
         var message_buffer: [x.create_colormap.len]u8 = undefined;
         x.create_colormap.serialize(&message_buffer, .{
             .id = ids.colormap(),
@@ -81,7 +79,7 @@ pub fn main() !u8 {
             .parent_window_id = screen.root,
             // Color depth:
             // - 24 for RGB
-            // - 32 for RGBA
+            // - 32 for ARGB
             .depth = depth,
             // Place it in the top-right corner of the screen
             .x = screen.pixel_width - window_width,
@@ -90,12 +88,12 @@ pub fn main() !u8 {
             .height = window_height,
             .border_width = 0, // TODO: what is this?
             .class = .input_output,
-            .visual_id = matching_visual_type.id, //screen.root_visual,
+            .visual_id = matching_visual_type.id,
         }, .{
             .bg_pixmap = .none,
             // 0xAARRGGBB
             .bg_pixel = 0xaa006660,
-            //            //.border_pixmap =
+            // .border_pixmap =
             .border_pixel = 0x00000000,
             .colormap = @enumFromInt(ids.colormap()),
             //            .bit_gravity = .north_west,

--- a/src/x11common.zig
+++ b/src/x11common.zig
@@ -7,7 +7,7 @@ pub const SocketReader = std.io.Reader(std.os.socket_t, std.os.RecvFromError, re
 pub fn send(sock: std.os.socket_t, data: []const u8) !void {
     const sent = try x.writeSock(sock, data, 0);
     if (sent != data.len) {
-        std.log.err("send {} only sent {}\n", .{ data.len, sent });
+        std.log.err("send {} only sent {}\n", .{data.len, sent});
         return error.DidNotSendAllData;
     }
 }
@@ -23,22 +23,31 @@ pub const ConnectResult = struct {
     }
 };
 
-pub fn connect(allocator: std.mem.Allocator) !ConnectResult {
-    const display = x.getDisplay();
+pub fn connectSetupMaxAuth(
+    sock: std.os.socket_t,
+    comptime max_auth_len: usize,
+    auth_name: x.Slice(u16, [*]const u8),
+    auth_data: x.Slice(u16, [*]const u8),
+) !?u16 {
+    var buf: [x.connect_setup.auth_offset + max_auth_len]u8 = undefined;
+    const len = x.connect_setup.getLen(auth_name.len, auth_data.len);
+    if (len > max_auth_len)
+        return error.AuthTooBig;
+    return connectSetup(sock, buf[0 .. len], auth_name, auth_data);
+}
 
-    const sock = x.connect(display) catch |err| {
-        std.log.err("failed to connect to display '{s}': {s}", .{ display, @errorName(err) });
-        std.os.exit(0xff);
-    };
+pub fn connectSetup(
+    sock: std.os.socket_t,
+    msg: []u8,
+    auth_name: x.Slice(u16, [*]const u8),
+    auth_data: x.Slice(u16, [*]const u8),
+) !?u16 {
+    std.debug.assert(msg.len == x.connect_setup.getLen(auth_name.len, auth_data.len));
 
-    {
-        const len = comptime x.connect_setup.getLen(0, 0);
-        var msg: [len]u8 = undefined;
-        x.connect_setup.serialize(&msg, 11, 0, .{ .ptr = undefined, .len = 0 }, .{ .ptr = undefined, .len = 0 });
-        try send(sock, &msg);
-    }
+    x.connect_setup.serialize(msg.ptr, 11, 0, auth_name, auth_data);
+    try send(sock, msg);
 
-    const reader = SocketReader{ .context = sock };
+    const reader = SocketReader { .context = sock };
     const connect_setup_header = try x.readConnectSetupHeader(reader, .{});
     switch (connect_setup_header.status) {
         .failed => {
@@ -55,18 +64,111 @@ pub fn connect(allocator: std.mem.Allocator) !ConnectResult {
         },
         .success => {
             // TODO: check version?
-            std.log.debug("SUCCESS! version {}.{}", .{ connect_setup_header.proto_major_ver, connect_setup_header.proto_minor_ver });
+            std.log.debug("SUCCESS! version {}.{}", .{connect_setup_header.proto_major_ver, connect_setup_header.proto_minor_ver});
+            return connect_setup_header.getReplyLen();
         },
         else => |status| {
             std.log.err("Error: expected 0, 1 or 2 as first byte of connect setup reply, but got {}", .{status});
             return error.MalformedXReply;
-        },
+        }
+    }
+}
+
+fn connectSetupAuth(
+    display_num: ?u32,
+    sock: std.os.socket_t,
+    auth_filename: []const u8,
+) !?u16 {
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // TODO: test bad auth
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    //if (try connectSetupMaxAuth(sock, 1000, .{ .ptr = "wat", .len = 3}, .{ .ptr = undefined, .len = 0})) |_|
+    //    @panic("todo");
+
+    const auth_mapped = try x.MappedFile.init(auth_filename, .{});
+    defer auth_mapped.unmap();
+
+    var auth_filter = x.AuthFilter{
+        .addr = .{ .family = .wild, .data = &[0]u8{ } },
+        .display_num = display_num,
+    };
+
+    var addr_buf: [x.max_sock_filter_addr]u8 = undefined;
+    if (auth_filter.applySocket(sock, &addr_buf)) {
+        std.log.debug("applied address filter {}", .{auth_filter.addr});
+    } else |err| {
+        // not a huge deal, we'll just try all auth methods
+        std.log.warn("failed to apply socket to auth filter with {s}", .{@errorName(err)});
     }
 
-    const connect_setup = x.ConnectSetup{
-        .buf = try allocator.allocWithOptions(u8, connect_setup_header.getReplyLen(), 4, null),
+    var auth_it = x.AuthIterator{ .mem = auth_mapped.mem };
+    while (auth_it.next() catch {
+        std.log.warn("auth file '{s}' is invalid", .{auth_filename});
+        return null;
+    }) |entry| {
+        if (auth_filter.isFiltered(auth_mapped.mem, entry)) |reason| {
+            std.log.debug("ignoring auth because {s} does not match: {}", .{@tagName(reason), entry.fmt(auth_mapped.mem)});
+            continue;
+        }
+        const name = entry.name(auth_mapped.mem);
+        const data = entry.data(auth_mapped.mem);
+        const name_x = x.Slice(u16, [*]const u8){
+            .ptr = name.ptr,
+            .len = @intCast(name.len),
+        };
+        const data_x = x.Slice(u16, [*]const u8){
+            .ptr = data.ptr,
+            .len = @intCast(data.len),
+        };
+        std.log.debug("trying auth {}", .{entry.fmt(auth_mapped.mem)});
+        if (try connectSetupMaxAuth(sock, 1000, name_x, data_x)) |reply_len|
+            return reply_len;
+    }
+
+    return null;
+}
+
+pub fn connect(allocator: std.mem.Allocator) !ConnectResult {
+    const display = x.getDisplay();
+    const parsed_display = x.parseDisplay(display) catch |err| {
+        std.log.err("invalid display '{s}': {s}", .{display, @errorName(err)});
+        std.os.exit(0xff);
+    };
+
+    const sock = x.connect(display, parsed_display) catch |err| {
+        std.log.err("failed to connect to display '{s}': {s}", .{display, @errorName(err)});
+        std.os.exit(0xff);
+    };
+    errdefer x.disconnect(sock);
+
+    const setup_reply_len: u16 = blk: {
+        if (try x.getAuthFilename(allocator)) |auth_filename| {
+            defer auth_filename.deinit(allocator);
+            if (try connectSetupAuth(parsed_display.display_num, sock, auth_filename.str)) |reply_len|
+                break :blk reply_len;
+        }
+
+        // Try no authentication
+        std.log.debug("trying no auth", .{});
+        var msg_buf: [x.connect_setup.getLen(0, 0)]u8 = undefined;
+        if (try connectSetup(
+            sock,
+            &msg_buf,
+            .{ .ptr = undefined, .len = 0 },
+            .{ .ptr = undefined, .len = 0 },
+        )) |reply_len| {
+            break :blk reply_len;
+        }
+
+        std.log.err("the X server rejected our connect setup message", .{});
+        std.os.exit(0xff);
+    };
+
+    const connect_setup = x.ConnectSetup {
+        .buf = try allocator.allocWithOptions(u8, setup_reply_len, 4, null),
     };
     std.log.debug("connect setup reply is {} bytes", .{connect_setup.buf.len});
+    const reader = SocketReader { .context = sock };
     try x.readFull(reader, connect_setup.buf);
 
     return ConnectResult{ .sock = sock, .setup = connect_setup };


### PR DESCRIPTION
Make the window transparent.

Fix https://github.com/MadLittleMods/fps-aim-analyzer/issues/1

Key points for supporting transparency (32-bit color depth):

 - Set a `create_window.Args.depth = 32`
 - Find a matching `matching_visual_type = try screen.findMatchingVisualType(32, .true_color, allocator);` and set it as the `create_window.Args.visual_id = matching_visual_type.id`
 - Set `window.options.bg_pixel = 0xaa006660` (can be any color `0xAARRGGBB`)
 - Set `window.Options.border_pixel = 0x00000000,` (needs to be set otherwise you get a `match` error but I don't see this visually pertain to anything)
 - Create a colormap using `.window_id = screen.root`, `.visual_id = matching_visual_type.id,`. Set `window.Options.colormap` to the colormap you just created

Requires a few changes to `zigx`:

 - https://github.com/marler8997/zigx/pull/8
 - https://github.com/marler8997/zigx/pull/9


Example:

![](https://github.com/MadLittleMods/fps-aim-analyzer/assets/558581/c651fb86-8c3d-4610-b7eb-3b2df034d844)

Tested with Zig 0.11.0 on Manjaro Linux (arch-based) with XFCE.


### Dev notes

 - https://stackoverflow.com/questions/3645632/how-to-create-a-window-with-a-bit-depth-of-32
 - https://stackoverflow.com/questions/41524843/create-a-32-bit-root-window-in-xlib
 - https://stackoverflow.com/questions/19410322/change-alpha-value-of-pixels-in-xlib-window/19418044#19418044
 - https://stackoverflow.com/questions/13395179/empty-or-transparent-window-with-xlib-showing-border-lines-only/13397150#13397150 

> X11 expects pre-multiplied colours
>
> *-- https://stackoverflow.com/questions/39906128/how-to-create-semi-transparent-white-window-in-xlib*
