### PR TITLE
Separate out and organize logic from `main.zig`

### DIFF
--- a/src/app_state.zig
+++ b/src/app_state.zig
@@ -1,0 +1,9 @@
+const render_utils = @import("render_utils.zig");
+
+/// Holds the overall state of the application. In an ideal world, this would be
+/// everything to reproduce the exact way the application looks at any given time.
+pub const AppState = struct {
+    window_dimensions: render_utils.Dimensions,
+    screenshot_capture_dimensions: render_utils.Dimensions,
+    mouse_x: i16 = 0,
+};

--- a/src/buffer_utils.zig
+++ b/src/buffer_utils.zig
@@ -1,0 +1,10 @@
+const std = @import("std");
+
+pub fn checkMessageLengthFitsInBuffer(message_length: usize, buffer_limit: usize) !void {
+    if (message_length > buffer_limit) {
+        std.debug.panic("Reply is bigger than our buffer (data corruption will ensue) {} > {}. In order to fix, increase the buffer size.", .{
+            message_length,
+            buffer_limit,
+        });
+    }
+}

--- a/src/buffer_utils.zig
+++ b/src/buffer_utils.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+/// Sanity check that we're not running into data integrity (corruption) issues caused
+/// by overflowing and wrapping around to the front ofq the buffer.
 pub fn checkMessageLengthFitsInBuffer(message_length: usize, buffer_limit: usize) !void {
     if (message_length > buffer_limit) {
         std.debug.panic("Reply is bigger than our buffer (data corruption will ensue) {} > {}. In order to fix, increase the buffer size.", .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -440,11 +440,11 @@ pub fn main() !u8 {
     };
 
     const render_context = RenderContext{
-        .sock = conn.sock,
-        .ids = ids,
-        .extensions = extensions,
-        .font_dims = font_dims,
-        .state = state,
+        .sock = &conn.sock,
+        .ids = &ids,
+        .extensions = &extensions,
+        .font_dims = &font_dims,
+        .state = &state,
     };
 
     while (true) {
@@ -587,18 +587,18 @@ fn renderString(
 }
 
 const RenderContext = struct {
-    sock: std.os.socket_t,
-    ids: Ids,
-    extensions: Extensions,
-    font_dims: FontDims,
-    state: State,
+    sock: *const std.os.socket_t,
+    ids: *const Ids,
+    extensions: *const Extensions,
+    font_dims: *const FontDims,
+    state: *const State,
 
-    pub fn render(self: @This()) !void {
-        const sock = self.sock;
-        const ids = self.ids;
-        const extensions = self.extensions;
-        const font_dims = self.font_dims;
-        const state = self.state;
+    pub fn render(self: *const @This()) !void {
+        const sock = self.sock.*;
+        const ids = self.ids.*;
+        const extensions = self.extensions.*;
+        const font_dims = self.font_dims.*;
+        const state = self.state.*;
 
         const window_id = ids.window;
         const screenshot_capture_dims = state.screenshot_capture_dims;
@@ -638,36 +638,6 @@ const RenderContext = struct {
                 mouse_x,
             },
         );
-        // {
-        //     const text_buf = msg[x.image_text8.text_offset .. x.image_text8.text_offset + 0xff];
-        //     const text_literal: []const u8 = std.fmt.bufPrint(text_buf, "Hello X! {d}", .{mouse_x});
-        //     const text = x.Slice(u8, [*]const u8){ .ptr = text_literal.ptr, .len = text_literal.len };
-        //     var msg: [x.image_text8.getLen(text.len)]u8 = undefined;
-
-        //     x.image_text8.serialize(&msg, text, .{
-        //         .drawable_id = window_id,
-        //         .gc_id = ids.fg_gc,
-        //         .x = @divTrunc((window_width - @as(i16, @intCast(text_width))), 2) + font_dims.font_left,
-        //         .y = @divTrunc((window_height - @as(i16, @intCast(font_dims.height))), 2) + font_dims.font_ascent,
-        //     });
-        //     try common.send(sock, &msg);
-        // }
-
-        // {
-        //     var msg: [x.copy_area.len]u8 = undefined;
-        //     x.copy_area.serialize(&msg, .{
-        //         .src_drawable_id = ids.pixmap,
-        //         .dst_drawable_id = ids.window,
-        //         .gc_id = ids.fg_gc,
-        //         .src_x = 0,
-        //         .src_y = 0,
-        //         .dst_x = 200,
-        //         .dst_y = 0,
-        //         .width = screenshot_capture_dims.width,
-        //         .height = screenshot_capture_dims.height,
-        //     });
-        //     try common.send(sock, &msg);
-        // }
 
         {
             var msg: [x.render.composite.len]u8 = undefined;
@@ -690,31 +660,14 @@ const RenderContext = struct {
     }
 
     pub fn captureScreenshotToPixmap(self: @This()) !void {
-        const sock = self.sock;
-        const ids = self.ids;
-        const extensions = self.extensions;
-        const state = self.state;
+        const sock = self.sock.*;
+        const ids = self.ids.*;
+        const extensions = self.extensions.*;
+        const state = self.state.*;
 
         const screenshot_capture_dims = state.screenshot_capture_dims;
 
         std.log.debug("captureScreenshotToPixmap", .{});
-
-        // {
-        //     var msg: [x.copy_area.len]u8 = undefined;
-        //     x.copy_area.serialize(&msg, .{
-        //         .src_drawable_id = ids.root,
-        //         .dst_drawable_id = ids.pixmap,
-        //         .gc_id = ids.copy_from_root_gc,
-        //         .src_x = (3840 / 2) - @divExact(@as(i16, @intCast(screenshot_capture_dims.width)), 2),
-        //         .src_y = (2160 / 2) - @divExact(@as(i16, @intCast(screenshot_capture_dims.height)), 2),
-        //         .dst_x = 0,
-        //         .dst_y = 0,
-        //         .width = screenshot_capture_dims.width,
-        //         .height = screenshot_capture_dims.height,
-        //     });
-        //     try common.send(sock, &msg);
-        // }
-
         {
             var msg: [x.render.composite.len]u8 = undefined;
             x.render.composite.serialize(&msg, extensions.render.opcode, .{

--- a/src/render_utils.zig
+++ b/src/render_utils.zig
@@ -1,0 +1,301 @@
+const std = @import("std");
+const x = @import("x");
+const common = @import("x11/x11_common.zig");
+const x11_extension_utils = @import("x11/x11_extension_utils.zig");
+const buffer_utils = @import("buffer_utils.zig");
+
+pub const Dimensions = struct {
+    width: u16,
+    height: u16,
+};
+
+pub const Ids = struct {
+    const Self = @This();
+
+    root: u32,
+    base: u32,
+    _current_id: u32,
+
+    window: u32 = 0,
+    colormap: u32 = 0,
+    bg_gc: u32 = 0,
+    fg_gc: u32 = 0,
+    pixmap: u32 = 0,
+    // For use with the X Render extension
+    picture_root: u32 = 0,
+    picture_window: u32 = 0,
+    picture_pixmap: u32 = 0,
+
+    pub fn init(root: u32, base: u32) Self {
+        var ids = Ids{
+            .root = root,
+            .base = base,
+            ._current_id = base,
+        };
+
+        ids.window = ids.generateMonotonicId();
+        ids.colormap = ids.generateMonotonicId();
+        ids.bg_gc = ids.generateMonotonicId();
+        ids.fg_gc = ids.generateMonotonicId();
+        ids.pixmap = ids.generateMonotonicId();
+        ids.picture_root = ids.generateMonotonicId();
+        ids.picture_window = ids.generateMonotonicId();
+        ids.picture_pixmap = ids.generateMonotonicId();
+
+        return ids;
+    }
+
+    /// Always increasing ID everytime the function is called
+    fn generateMonotonicId(self: *Ids) u32 {
+        const current_id = self._current_id;
+        self._current_id += 1;
+        return current_id;
+    }
+};
+
+pub fn findMatchingPictureFormat(formats: []const x.render.PictureFormatInfo, desired_depth: u8) !x.render.PictureFormatInfo {
+    for (formats) |format| {
+        if (format.depth != desired_depth) continue;
+        return format;
+    }
+    return error.PictureFormatNotFound;
+}
+
+pub fn createResources(
+    sock: std.os.socket_t,
+    buffer: *x.ContiguousReadBuffer,
+    ids: *const Ids,
+    screen: *align(4) x.Screen,
+    extensions: *const x11_extension_utils.Extensions,
+    depth: u8,
+    window_dimensions: Dimensions,
+    screenshot_capture_dimensions: Dimensions,
+) !void {
+    const reader = common.SocketReader{ .context = sock };
+    const buffer_limit = buffer.half_len;
+
+    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+    //
+    const matching_visual_type = try screen.findMatchingVisualType(
+        depth,
+        .true_color,
+        allocator,
+    );
+    std.log.debug("matching_visual_type {any}", .{matching_visual_type});
+
+    // We just need some colormap to provide when creating the window in order to avoid
+    // a "bad" `match` error when working with a 32-bit depth.
+    {
+        std.log.debug("Creating colormap {0} 0x{0x}", .{ids.colormap});
+        var message_buffer: [x.create_colormap.len]u8 = undefined;
+        x.create_colormap.serialize(&message_buffer, .{
+            .id = ids.colormap,
+            .window_id = ids.root,
+            .visual_id = matching_visual_type.id,
+            .alloc = .none,
+        });
+        try common.send(sock, &message_buffer);
+    }
+    {
+        std.log.debug("Creating window_id {0} 0x{0x}", .{ids.window});
+        var message_buffer: [x.create_window.max_len]u8 = undefined;
+        const len = x.create_window.serialize(&message_buffer, .{
+            .window_id = ids.window,
+            .parent_window_id = ids.root,
+            // Color depth:
+            // - 24 for RGB
+            // - 32 for ARGB
+            .depth = depth,
+            // Place it in the top-right corner of the screen
+            .x = screen.pixel_width - window_dimensions.width,
+            .y = 0,
+            .width = window_dimensions.width,
+            .height = window_dimensions.height,
+            // It's unclear what this is for, but we just need to set it to something
+            // since it's one of the arguments.
+            .border_width = 0,
+            .class = .input_output,
+            .visual_id = matching_visual_type.id,
+        }, .{
+            .bg_pixmap = .none,
+            // 0xAARRGGBB
+            // Required when `depth` is set to 32
+            .bg_pixel = 0xaa006660,
+            // .border_pixmap =
+            // Required when `depth` is set to 32
+            .border_pixel = 0x00000000,
+            // Required when `depth` is set to 32
+            .colormap = @enumFromInt(ids.colormap),
+            // .bit_gravity = .north_west,
+            // .win_gravity = .east,
+            // .backing_store = .when_mapped,
+            // .backing_planes = 0x1234,
+            // .backing_pixel = 0xbbeeeeff,
+            //
+            // Whether this window overrides structure control facilities. Basically, a
+            // suggestion whether the window manager to decorate this window (false) or
+            // we want to override the behavior. We set this to true to disable the
+            // window controls (basically a borderless window).
+            .override_redirect = true,
+            // .save_under = true,
+            .event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,
+            // .dont_propagate = 1,
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+
+    {
+        std.log.info("background_graphics_context_id {0} 0x{0x}", .{ids.bg_gc});
+        var message_buffer: [x.create_gc.max_len]u8 = undefined;
+        const len = x.create_gc.serialize(&message_buffer, .{
+            .gc_id = ids.bg_gc,
+            .drawable_id = ids.window,
+        }, .{
+            .background = 0xff000000,
+            .foreground = 0xff0000ff,
+            // prevent NoExposure events when we send CopyArea
+            .graphics_exposures = false,
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+    {
+        std.log.info("foreground_graphics_context_id {0} 0x{0x}", .{ids.fg_gc});
+        var message_buffer: [x.create_gc.max_len]u8 = undefined;
+        const len = x.create_gc.serialize(&message_buffer, .{
+            .gc_id = ids.fg_gc,
+            .drawable_id = ids.window,
+        }, .{
+            .background = 0xff000000,
+            .foreground = 0xffffff00,
+            // prevent NoExposure events when we send CopyArea
+            .graphics_exposures = false,
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+
+    // Create a pixmap drawable to capture the screenshot onto
+    {
+        var message_buffer: [x.create_pixmap.len]u8 = undefined;
+        x.create_pixmap.serialize(&message_buffer, .{
+            .id = ids.pixmap,
+            .drawable_id = ids.window,
+            .depth = depth,
+            .width = screenshot_capture_dimensions.width,
+            .height = screenshot_capture_dimensions.height,
+        });
+        try common.send(sock, &message_buffer);
+    }
+
+    // Find some compatible picture formats for use with the X Render extension. We want
+    // to find a 24-bit depth format for use with the root window and a 32-bit depth
+    // format for use with our window.
+    {
+        var message_buffer: [x.render.query_pict_formats.len]u8 = undefined;
+        x.render.query_pict_formats.serialize(&message_buffer, extensions.render.opcode);
+        try common.send(sock, &message_buffer);
+    }
+    const message_length = try x.readOneMsg(reader, @alignCast(buffer.nextReadBuffer()));
+    try buffer_utils.checkMessageLengthFitsInBuffer(message_length, buffer_limit);
+    const optional_picture_formats_data: ?struct { matching_picture_format_24: x.render.PictureFormatInfo, matching_picture_format_32: x.render.PictureFormatInfo } = blk: {
+        switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
+            .reply => |msg_reply| {
+                const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
+                std.log.info("RENDER extension: pict formats num_formats={}, num_screens={}, num_depths={}, num_visuals={}", .{
+                    msg.num_formats,
+                    msg.num_screens,
+                    msg.num_depths,
+                    msg.num_visuals,
+                });
+                for (msg.getPictureFormats(), 0..) |format, i| {
+                    std.log.info("RENDER extension: pict format ({}) {any}", .{
+                        i,
+                        format,
+                    });
+                }
+                break :blk .{
+                    .matching_picture_format_24 = try findMatchingPictureFormat(msg.getPictureFormats()[0..], 24),
+                    .matching_picture_format_32 = try findMatchingPictureFormat(msg.getPictureFormats()[0..], 32),
+                };
+            },
+            else => |msg| {
+                std.log.err("expected a reply for `x.render.query_pict_formats` but got {}", .{msg});
+                return error.ExpectedReplyButGotSomethingElse;
+            },
+        }
+    };
+    const picture_formats_data = optional_picture_formats_data orelse @panic("Matching picture formats not found");
+    const matching_picture_format = switch (depth) {
+        24 => picture_formats_data.matching_picture_format_24,
+        32 => picture_formats_data.matching_picture_format_32,
+        else => |captured_depth| {
+            std.log.err("Matching picture format not found for depth {}", .{captured_depth});
+            @panic("Matching picture format not found for depth");
+        },
+    };
+
+    // We need to create a picture for every drawable that we want to use with the X
+    // Render extension
+    // =============================================================================
+    //
+    // Create a picture for the root window that we will use to capture the screenshot from
+    {
+        var message_buffer: [x.render.create_picture.max_len]u8 = undefined;
+        const len = x.render.create_picture.serialize(&message_buffer, extensions.render.opcode, .{
+            .picture_id = ids.picture_root,
+            .drawable_id = screen.root,
+            // The root window is always 24-bit depth
+            .format_id = picture_formats_data.matching_picture_format_24.picture_format_id,
+            .options = .{
+                .subwindow_mode = .include_inferiors,
+            },
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+
+    // Create a picture for the our window that we can copy and composite things onto
+    {
+        var message_buffer: [x.render.create_picture.max_len]u8 = undefined;
+        const len = x.render.create_picture.serialize(&message_buffer, extensions.render.opcode, .{
+            .picture_id = ids.picture_window,
+            .drawable_id = ids.window,
+            .format_id = matching_picture_format.picture_format_id,
+            .options = .{},
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+
+    // Create a picture for the pixmap that we store screenshots in
+    {
+        var message_buffer: [x.render.create_picture.max_len]u8 = undefined;
+        const len = x.render.create_picture.serialize(&message_buffer, extensions.render.opcode, .{
+            .picture_id = ids.picture_pixmap,
+            .drawable_id = ids.pixmap,
+            .format_id = matching_picture_format.picture_format_id,
+            .options = .{},
+        });
+        try common.send(sock, message_buffer[0..len]);
+    }
+}
+
+pub fn cleanupResources(
+    sock: std.os.socket_t,
+    ids: *const Ids,
+) !void {
+    {
+        var message_buffer: [x.free_pixmap.len]u8 = undefined;
+        x.free_pixmap.serialize(&message_buffer, ids.pixmap);
+        try common.send(sock, &message_buffer);
+    }
+
+    {
+        var message_buffer: [x.free_colormap.len]u8 = undefined;
+        x.free_colormap.serialize(&message_buffer, ids.colormap);
+        try common.send(sock, &message_buffer);
+    }
+
+    // TODO: free_gc
+
+    // TODO: x.render.free_picture
+}

--- a/src/x11/x11_extension_utils.zig
+++ b/src/x11/x11_extension_utils.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const x = @import("x");
+const common = @import("./x11_common.zig");
+const buffer_utils = @import("../buffer_utils.zig");
+
+pub const ExtensionInfo = struct {
+    extension_name: []const u8,
+    opcode: u8,
+    base_error_code: u8,
+};
+
+pub const Extensions = struct {
+    render: ExtensionInfo,
+};
+
+pub fn getExtensionInfo(
+    sock: std.os.socket_t,
+    buffer: *x.ContiguousReadBuffer,
+    comptime extension_name: []const u8,
+) !?ExtensionInfo {
+    const reader = common.SocketReader{ .context = sock };
+    const buffer_limit = buffer.half_len;
+
+    {
+        const ext_name = comptime x.Slice(u16, [*]const u8).initComptime(extension_name);
+        var message_buffer: [x.query_extension.getLen(ext_name.len)]u8 = undefined;
+        x.query_extension.serialize(&message_buffer, ext_name);
+        try common.send(sock, &message_buffer);
+    }
+    const message_length = try x.readOneMsg(reader, @alignCast(buffer.nextReadBuffer()));
+    try buffer_utils.checkMessageLengthFitsInBuffer(message_length, buffer_limit);
+    const optional_render_extension = blk: {
+        switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
+            .reply => |msg_reply| {
+                const msg: *x.ServerMsg.QueryExtension = @ptrCast(msg_reply);
+                if (msg.present == 0) {
+                    std.log.info("RENDER extension: not present", .{});
+                    break :blk null;
+                }
+                std.debug.assert(msg.present == 1);
+                std.log.info("RENDER extension: opcode={} base_error_code={}", .{ msg.major_opcode, msg.first_error });
+                std.log.info("RENDER extension: {}", .{msg});
+                break :blk ExtensionInfo{
+                    .extension_name = extension_name,
+                    .opcode = msg.major_opcode,
+                    .base_error_code = msg.first_error,
+                };
+            },
+            else => |msg| {
+                std.log.err("expected a reply for `x.query_extension` but got {}", .{msg});
+                return error.ExpectedReplyButGotSomethingElse;
+            },
+        }
+    };
+
+    return optional_render_extension;
+}

--- a/src/x11/x_render_extension.zig
+++ b/src/x11/x_render_extension.zig
@@ -1,0 +1,50 @@
+// X Render Extension
+//
+// - Docs:
+//    - https://www.x.org/releases/X11R7.5/doc/renderproto/renderproto.txt
+//    - https://www.keithp.com/~keithp/render/protocol.html
+// - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/98eeebfc2d7db5377b85437418fb942ea30ffc0d/src/render.xml
+
+const std = @import("std");
+const x = @import("x");
+const common = @import("./x11_common.zig");
+const x11_extension_utils = @import("./x11_extension_utils.zig");
+const buffer_utils = @import("../buffer_utils.zig");
+
+pub fn ensureCompatibleVersionOfXRenderExtension(
+    sock: std.os.socket_t,
+    buffer: *x.ContiguousReadBuffer,
+    render_extension: *const x11_extension_utils.ExtensionInfo,
+) !void {
+    const reader = common.SocketReader{ .context = sock };
+    const buffer_limit = buffer.half_len;
+
+    {
+        var message_buffer: [x.render.query_version.len]u8 = undefined;
+        x.render.query_version.serialize(&message_buffer, render_extension.opcode, .{
+            .major_version = 0,
+            .minor_version = 11,
+        });
+        try common.send(sock, &message_buffer);
+    }
+    const message_length = try x.readOneMsg(reader, @alignCast(buffer.nextReadBuffer()));
+    try buffer_utils.checkMessageLengthFitsInBuffer(message_length, buffer_limit);
+    switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
+        .reply => |msg_reply| {
+            const msg: *x.render.query_version.Reply = @ptrCast(msg_reply);
+            std.log.info("RENDER extension: version {}.{}", .{ msg.major_version, msg.minor_version });
+            if (msg.major_version != 0) {
+                std.log.err("X Render extension major version {} too new", .{msg.major_version});
+                return error.XRenderExtensionTooNew;
+            }
+            if (msg.minor_version < 11) {
+                std.log.err("X Render extension minor version {} too old", .{msg.minor_version});
+                return error.XRenderExtensionTooOld;
+            }
+        },
+        else => |msg| {
+            std.log.err("expected a reply for `x.render.query_version` but got {}", .{msg});
+            return error.ExpectedReplyButGotSomethingElse;
+        },
+    }
+}


### PR DESCRIPTION
Separate out and organize logic from `main.zig` so we can avoid the big ball of hard to reason about code.

For reference, this is what the app looks like at the moment:

 - Transparent window
 - Small screenshot of the middle portion of the screen captured on window click and displayed in the top-right corner
 - Text in the middle of the screen that updates and displays the mouse X position

![](https://github.com/MadLittleMods/fps-aim-analyzer/assets/558581/61b61cd0-a947-4148-9e8e-830c5e55a305)

