### PR TITLE
Capture multiple screenshots

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -20,6 +20,18 @@ Guides:
 
  - A walkthrough of using the X Window system, https://magcius.github.io/xplain/article/index.html
 
+#### Extensions
+
+See the note below on *"Finding installed extensions to the X.org server"* to discover all of what you can use.
+
+In this project, we rely on the X Render Extension to handle the screenshot capturing from an opaque window and compositing it on top of our transparent window. With normal X operations, you can't mix different depths (24-bit RGB vs 32-bit ARGB).
+
+ - The X Rendering Extension protocol docs:
+    - https://www.keithp.com/~keithp/render/protocol.html
+    - https://www.x.org/releases/X11R7.5/doc/renderproto/renderproto.txt
+ - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/98eeebfc2d7db5377b85437418fb942ea30ffc0d/src/render.xml
+ - C library: https://gitlab.freedesktop.org/xorg/lib/libxrender
+
 
 #### Debugging
 

--- a/src/app_state.zig
+++ b/src/app_state.zig
@@ -3,13 +3,25 @@ const render_utils = @import("render_utils.zig");
 /// Holds the overall state of the application. In an ideal world, this would be
 /// everything to reproduce the exact way the application looks at any given time.
 pub const AppState = struct {
+    /// The pixel dimensions of the screen/monitor
     root_screen_dimensions: render_utils.Dimensions,
+    /// The pixel dimensions of our window
     window_dimensions: render_utils.Dimensions,
+    /// The pixel dimensions of how big each screenshot capture should be.
     screenshot_capture_dimensions: render_utils.Dimensions,
+
+    /// The max number of screenshots that will be stored and displayed.
     max_screenshots_shown: u8,
-    current_screenshot_index: u8 = 0,
+    /// The index of the next screenshot to be taken. This is used to determine
+    /// the stack position in the pixmap to copy to. And the index before represents
+    /// the most recent screenshot taken.
+    next_screenshot_index: u8 = 0,
+
+    /// The margin space around the window from the edge of the screen.
     margin: i16,
+    /// The amount of spacing between each screenshot.
     padding: i16,
 
+    /// The current mouse position relative to the window.
     mouse_x: i16 = 0,
 };

--- a/src/app_state.zig
+++ b/src/app_state.zig
@@ -7,6 +7,7 @@ pub const AppState = struct {
     window_dimensions: render_utils.Dimensions,
     screenshot_capture_dimensions: render_utils.Dimensions,
     max_screenshots_shown: u8,
+    current_screenshot_index: u8 = 0,
     margin: i16,
     padding: i16,
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,11 +49,11 @@ pub fn main() !u8 {
     };
 
     const max_screenshots_shown = 6;
-    const margin = 10;
+    const margin = 20;
     const padding = 10;
     const window_dimensions = render_utils.Dimensions{
         .width = screenshot_capture_dimensions.width + (2 * padding),
-        .height = (max_screenshots_shown * (screenshot_capture_dimensions.height + (2 * padding))),
+        .height = (max_screenshots_shown * (screenshot_capture_dimensions.height + padding)) + padding,
     };
 
     var state = AppState{
@@ -157,7 +157,7 @@ pub fn main() !u8 {
         try conn.send(&msg);
     }
 
-    const render_context = render_utils.RenderContext{
+    var render_context = render_utils.RenderContext{
         .sock = &conn.sock,
         .ids = &ids,
         .extensions = &extensions,


### PR DESCRIPTION
Capture multiple screenshots

Follow-up to https://github.com/MadLittleMods/fps-aim-analyzer/pull/3

Each click on the window captures a new screenshot of the middle of the screen.

We store all captured screenshots in the same `pixmap` in a film strip layout stacked on top of each other. We only keep track of the N most recent screenshots (defined by max_screenshots_shown).



![](https://github.com/MadLittleMods/fps-aim-analyzer/assets/558581/d0473e81-5927-4a22-b6d3-ea62febca580)
