### PR TITLE
Track any click

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .zigx = .{
-            .url = "https://github.com/MadLittleMods/zigx/archive/ad97e8925f897a6e6cd36f42532d5a0a104d0278.tar.gz",
-            .hash = "12203605dbc064c7c1bbbf3bb98d2521ca8d059d86a75b44eb2fefac469e1d8b6e68",
+            .url = "https://github.com/MadLittleMods/zigx/archive/bf27262d7bb54313b5d3723aca2c43a1766ad8b6.tar.gz",
+            .hash = "1220c8b01c95fddc74233ada73b4b204a279a53fb9498816cea6aadc31194b3a9103",
         },
     },
 }

--- a/src/x11/x11_extension_utils.zig
+++ b/src/x11/x11_extension_utils.zig
@@ -17,6 +17,7 @@ pub const ExtensionInfo = struct {
 /// A map of X server extension names to their info.
 pub const Extensions = struct {
     render: ExtensionInfo,
+    input: ExtensionInfo,
 };
 
 /// Determines whether the extension is available on the server.

--- a/src/x11/x_input_extension.zig
+++ b/src/x11/x_input_extension.zig
@@ -1,9 +1,7 @@
-// X Render Extension
+// X Input Extension
 //
-// - Docs:
-//    - https://www.x.org/releases/X11R7.5/doc/renderproto/renderproto.txt
-//    - https://www.keithp.com/~keithp/render/protocol.html
-// - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/98eeebfc2d7db5377b85437418fb942ea30ffc0d/src/render.xml
+// - Docs: https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt
+// - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/1388374c7149114888a6a5cd6e9bf6ad4b42adf8/src/xinput.xml
 
 const std = @import("std");
 const x = @import("x");
@@ -11,23 +9,23 @@ const common = @import("./x11_common.zig");
 const x11_extension_utils = @import("./x11_extension_utils.zig");
 const buffer_utils = @import("../buffer_utils.zig");
 
-/// Check to make sure we're using a compatible version of the X Render extension
+/// Check to make sure we're using a compatible version of the X Input extension
 /// that supports all of the features we need.
-pub fn ensureCompatibleVersionOfXRenderExtension(
+pub fn ensureCompatibleVersionOfXInputExtension(
     sock: std.os.socket_t,
     buffer: *x.ContiguousReadBuffer,
-    render_extension: *const x11_extension_utils.ExtensionInfo,
+    input_extension: *const x11_extension_utils.ExtensionInfo,
     version: struct {
-        major_version: u32,
-        minor_version: u32,
+        major_version: u16,
+        minor_version: u16,
     },
 ) !void {
     const reader = common.SocketReader{ .context = sock };
     const buffer_limit = buffer.half_len;
 
     {
-        var message_buffer: [x.render.query_version.len]u8 = undefined;
-        x.render.query_version.serialize(&message_buffer, render_extension.opcode, .{
+        var message_buffer: [x.inputext.query_version.len]u8 = undefined;
+        x.inputext.query_version.serialize(&message_buffer, input_extension.opcode, .{
             .major_version = version.major_version,
             .minor_version = version.minor_version,
         });
@@ -37,27 +35,27 @@ pub fn ensureCompatibleVersionOfXRenderExtension(
     try buffer_utils.checkMessageLengthFitsInBuffer(message_length, buffer_limit);
     switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
         .reply => |msg_reply| {
-            const msg: *x.render.query_version.Reply = @ptrCast(msg_reply);
-            std.log.info("X Render extension: version {}.{}", .{ msg.major_version, msg.minor_version });
+            const msg: *x.inputext.query_version.Reply = @ptrCast(msg_reply);
+            std.log.info("X Input extension: version {}.{}", .{ msg.major_version, msg.minor_version });
             if (msg.major_version != version.major_version) {
-                std.log.err("X Render extension major version is {} but we expect {}", .{
+                std.log.err("X Input extension major version is {} but we expect {}", .{
                     msg.major_version,
                     version.major_version,
                 });
-                return error.XRenderExtensionTooNew;
+                return error.XInputExtensionTooNew;
             }
             if (msg.minor_version < version.minor_version) {
-                std.log.err("X Render extension minor version is {}.{} but I've only tested >= {}.{})", .{
+                std.log.err("X Input extension minor version is {}.{} but I've only tested >= {}.{})", .{
                     msg.major_version,
                     msg.minor_version,
                     version.major_version,
                     version.minor_version,
                 });
-                return error.XRenderExtensionTooOld;
+                return error.XInputExtensionTooOld;
             }
         },
         else => |msg| {
-            std.log.err("expected a reply for `x.render.query_version` but got {}", .{msg});
+            std.log.err("expected a reply for `x.inputext.query_version` but got {}", .{msg});
             return error.ExpectedReplyButGotSomethingElse;
         },
     }


### PR DESCRIPTION
Track any click

Before this PR, we could only detect when you clicked on our own window.

With this PR, we can detect a click event wherever it happens to be and trigger a screenshot. This way when you're playing game, screenshots are still taken as you play.

![](https://github.com/MadLittleMods/fps-aim-analyzer/assets/558581/d5d7539d-f5f5-440d-9863-8bda58e1f68e)





### Dev notes

 - https://stackoverflow.com/questions/37321038/x11-detect-general-mouse-and-keyboard-events
 - https://keithp.com/blogs/Cursor_tracking/
 - http://who-t.blogspot.com/2009/05/xi2-recipes-part-1.html


X Input extension:

 - The X Input Extension protocol docs:
    - https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt
 - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/1388374c7149114888a6a5cd6e9bf6ad4b42adf8/src/xinput.xml
 - C library: https://gitlab.freedesktop.org/xorg/lib/libxi



Other resources:

 - https://unix.stackexchange.com/questions/183910/highlight-current-mouse-position/228674#228674