### PR TITLE
Add basic mouse click throttle for screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Tested with Zig 0.11.0
 zig build run
 ```
 
+![](https://github.com/MadLittleMods/fps-aim-analyzer/assets/558581/d5d7539d-f5f5-440d-9863-8bda58e1f68e)
+
 
 ### Dev notes
 

--- a/src/app_state.zig
+++ b/src/app_state.zig
@@ -22,6 +22,8 @@ pub const AppState = struct {
     /// The amount of spacing between each screenshot.
     padding: i16,
 
+    last_click_ts: u32 = 0,
+
     /// The current mouse position relative to the window.
     mouse_x: i16 = 0,
 };

--- a/src/render_utils.zig
+++ b/src/render_utils.zig
@@ -177,7 +177,7 @@ pub fn createResources(
             // window controls (basically a borderless window).
             .override_redirect = true,
             // .save_under = true,
-            .event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,
+            //.event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,
             // .dont_propagate = 1,
         });
         try common.send(sock, message_buffer[0..len]);


### PR DESCRIPTION
Add basic mouse click throttle for screenshots because I tend to click a lot more than the gun can fire.

### Dev notes

One thing I am noticing easily is that input lag on the game is significant (or the [aim assist/forgiveness, bullet magnetism](https://www.youtube.com/watch?v=yv3lRNAxA0o) [*(Reddit source)*](https://www.reddit.com/r/halo/comments/10kvrz7/how_aim_assist_actually_works/), [*(Twitter source)*](https://twitter.com/t3h_m00kz/status/1618182723050561536)). The screenshot taken on click is often way off from where it registered the hit. This isn't exactly surprising  but the magnitude is a bit more than I would think.

I think we might have to looking at the ammo count change to trigger screenshots.

