### PR TITLE
Resolve window stacking in tests

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
     },
     .dependencies = .{
         .zigx = .{
-            .url = "https://github.com/MadLittleMods/zigx/archive/7012ac6ae0923a8c55385bcd9124fa8ea273992d.tar.gz",
-            .hash = "1220209ddad630b88fbc996f44cc9e70a79c7ba0d51726f24a77b5f08a4873c74b3c",
+            .url = "https://github.com/MadLittleMods/zigx/archive/33a9d18cc8edd7c39f0332d1d486f229fc1f506b.tar.gz",
+            .hash = "12201510274588b6467577208baaff9cc3ad640ba7b25fe3140279ad65a4460239f4",
         },
         .zigimg = .{
             .url = "https://github.com/MadLittleMods/zigimg/archive/ccf9197ccf96dd43d1d31c98a86f21e74187d0c4.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
     },
     .dependencies = .{
         .zigx = .{
-            .url = "https://github.com/MadLittleMods/zigx/archive/46a751c486d25832954412440dc7082476ae49a9.tar.gz",
-            .hash = "1220b8e05f669793b32a654f0215dbd4fcc22a44aa4c79da849a2c21f461d5d25b69",
+            .url = "https://github.com/MadLittleMods/zigx/archive/7012ac6ae0923a8c55385bcd9124fa8ea273992d.tar.gz",
+            .hash = "1220209ddad630b88fbc996f44cc9e70a79c7ba0d51726f24a77b5f08a4873c74b3c",
         },
         .zigimg = .{
             .url = "https://github.com/MadLittleMods/zigimg/archive/ccf9197ccf96dd43d1d31c98a86f21e74187d0c4.tar.gz",

--- a/src/aim_analyzer/render.zig
+++ b/src/aim_analyzer/render.zig
@@ -237,8 +237,8 @@ pub fn createResources(
                 const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
                 const picture_formats = msg.getPictureFormats();
                 break :blk .{
-                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 24),
-                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 32),
+                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats, 24),
+                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats, 32),
                 };
             },
             else => |msg| {

--- a/src/aim_analyzer/render.zig
+++ b/src/aim_analyzer/render.zig
@@ -237,8 +237,14 @@ pub fn createResources(
                 const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
                 const picture_formats = msg.getPictureFormats();
                 break :blk .{
-                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats, 24),
-                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats, 32),
+                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(
+                        picture_formats,
+                        24,
+                    ),
+                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(
+                        picture_formats,
+                        32,
+                    ),
                 };
             },
             else => |msg| {

--- a/src/aim_analyzer/render.zig
+++ b/src/aim_analyzer/render.zig
@@ -235,21 +235,10 @@ pub fn createResources(
         switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
             .reply => |msg_reply| {
                 const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
-                // std.log.debug("RENDER extension: pict formats num_formats={}, num_screens={}, num_depths={}, num_visuals={}", .{
-                //     msg.num_formats,
-                //     msg.num_screens,
-                //     msg.num_depths,
-                //     msg.num_visuals,
-                // });
-                // for (msg.getPictureFormats(), 0..) |format, i| {
-                //     std.log.debug("RENDER extension: pict format ({}) {any}", .{
-                //         i,
-                //         format,
-                //     });
-                // }
+                const picture_formats = msg.getPictureFormats();
                 break :blk .{
-                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(msg.getPictureFormats()[0..], 24),
-                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(msg.getPictureFormats()[0..], 32),
+                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 24),
+                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 32),
                 };
             },
             else => |msg| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -169,15 +169,15 @@ const MainProgram = struct {
         {
             const window_name = comptime x.Slice(u16, [*]const u8).initComptime("Aim Analyzer");
             const change_property = x.change_property.withFormat(u8);
-            var msg_buf: [change_property.getLen(window_name.len)]u8 = undefined;
-            change_property.serialize(&msg_buf, .{
+            var message_buffer: [change_property.getLen(window_name.len)]u8 = undefined;
+            change_property.serialize(&message_buffer, .{
                 .mode = .replace,
                 .window_id = ids.window,
                 .property = x.Atom.WM_NAME,
                 .type = x.Atom.STRING,
                 .values = window_name,
             });
-            try conn.send(msg_buf[0..]);
+            try conn.send(message_buffer[0..]);
         }
 
         // Set a custom application ID property that we can use to find the window from
@@ -195,15 +195,15 @@ const MainProgram = struct {
             {
                 const window_name = comptime x.Slice(u16, [*]const u8).initComptime("aim_analyzer");
                 const change_property = x.change_property.withFormat(u8);
-                var msg_buf: [change_property.getLen(window_name.len)]u8 = undefined;
-                change_property.serialize(&msg_buf, .{
+                var message_buffer: [change_property.getLen(window_name.len)]u8 = undefined;
+                change_property.serialize(&message_buffer, .{
                     .mode = .replace,
                     .window_id = ids.window,
                     .property = custom_app_id_atom,
                     .type = x.Atom.STRING,
                     .values = window_name,
                 });
-                try conn.send(msg_buf[0..]);
+                try conn.send(message_buffer[0..]);
             }
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -215,6 +215,18 @@ const MainProgram = struct {
             try conn.send(&msg);
         }
 
+        // TODO: Maybe remove. Just trying to make this window always on top (above
+        // `screen_play` in the tests)
+        {
+            var msg: [x.configure_window.max_len]u8 = undefined;
+            const len = x.configure_window.serialize(&msg, .{
+                .window_id = ids.window,
+            }, .{
+                .stack_mode = .above,
+            });
+            try conn.send(msg[0..len]);
+        }
+
         var render_context = render.RenderContext{
             .sock = &conn.sock,
             .ids = &ids,
@@ -342,7 +354,14 @@ pub fn main() !void {
 test "end-to-end: click to capture screenshot" {
     const allocator = std.testing.allocator;
 
-    // Ideally, we'd be able to build in run in the same command like `zig build
+    // FIXME: Without a "compositing manager", the window will not show up as
+    // transparent. We could make a basic one from scratch using the X `COMPOSITE`
+    // extension. See https://magcius.github.io/xplain/article/composite.html for a
+    // breakdown on how compositing works. Normally, you'd get this same functionality
+    // for free via your desktop environment's window manager which probably includes a
+    // "compositing manager".
+
+    // Ideally, we'd be able to build and run in the same command like `zig build
     // run-main` but https://github.com/ziglang/zig/issues/20853 prevents us from being
     // able to kill the process cleanly. So we have to build and run in separate
     // commands.

--- a/src/main.zig
+++ b/src/main.zig
@@ -390,7 +390,7 @@ test "end-to-end: click to capture screenshot" {
     // keyframes
     try screen_play_process.spawn();
 
-    // Run the main aim_analyzer process in a background thread We use a thread instead
+    // Run the main aim_analyzer process in a background thread. We use a thread instead
     // of a child process so we can inspect the internal app state.
     var main_program = MainProgram{};
     const main_thread = try std.Thread.spawn(

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -173,6 +173,18 @@ pub fn main() !void {
         try conn.send(&msg);
     }
 
+    // Try to make this window on the bottom (below the main `aim_analyzer` in the
+    // tests).
+    {
+        var msg: [x.configure_window.max_len]u8 = undefined;
+        const len = x.configure_window.serialize(&msg, .{
+            .window_id = ids.window,
+        }, .{
+            .stack_mode = .below,
+        });
+        try conn.send(msg[0..len]);
+    }
+
     var render_context = render.RenderContext{
         .sock = &conn.sock,
         .ids = &ids,

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -167,9 +167,9 @@ pub fn main() !void {
     // During tests, find the `aim_analyzer` window so we can stack our window below it.
     {
         {
-            var msg_buf: [x.query_tree.len]u8 = undefined;
-            x.query_tree.serialize(&msg_buf, screen.root);
-            try conn.send(msg_buf[0..]);
+            var message_buffer: [x.query_tree.len]u8 = undefined;
+            x.query_tree.serialize(&message_buffer, screen.root);
+            try conn.send(message_buffer[0..]);
         }
         const window_list = blk: {
             const message_length = try x.readOneMsg(conn.reader(), @alignCast(buffer.nextReadBuffer()));
@@ -203,8 +203,8 @@ pub fn main() !void {
             for (window_list) |window_id| {
                 // Fetch the custom application ID property for each window
                 {
-                    var msg_buf: [x.get_property.len]u8 = undefined;
-                    x.get_property.serialize(&msg_buf, .{
+                    var message_buffer: [x.get_property.len]u8 = undefined;
+                    x.get_property.serialize(&message_buffer, .{
                         .window_id = window_id,
                         .property = custom_app_id_atom,
                         .type = x.Atom.STRING,
@@ -212,7 +212,7 @@ pub fn main() !void {
                         .len = 64,
                         .delete = false,
                     });
-                    try conn.send(msg_buf[0..]);
+                    try conn.send(message_buffer[0..]);
                 }
                 const message_length = try x.readOneMsg(conn.reader(), @alignCast(buffer.nextReadBuffer()));
                 try common.checkMessageLengthFitsInBuffer(message_length, buffer_limit);

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -166,6 +166,7 @@ pub fn main() !void {
 
     // During tests, find the `aim_analyzer` window so we can stack our window below it.
     {
+        // First, list all the child windows of the root window
         {
             var message_buffer: [x.query_tree.len]u8 = undefined;
             x.query_tree.serialize(&message_buffer, screen.root);
@@ -198,6 +199,7 @@ pub fn main() !void {
             &buffer,
             comptime x.Slice(u16, [*]const u8).initComptime("madlittlemods.app_id"),
         );
+
         // Find the matching window ID with the custom application ID property of "aim_analyzer"
         const opt_aim_analyzer_window_id = blk: {
             for (window_list) |window_id| {
@@ -236,8 +238,7 @@ pub fn main() !void {
             break :blk null;
         };
 
-        // Try to make this window on the bottom (below the main `aim_analyzer` in the
-        // tests).
+        // Update the window to be below the main `aim_analyzer` in the tests.
         if (opt_aim_analyzer_window_id) |aim_analyzer_window_id| {
             std.log.debug("Stacking screen_play window below aim_analyzer window ID {}", .{aim_analyzer_window_id});
             var msg: [x.configure_window.max_len]u8 = undefined;

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -191,6 +191,7 @@ pub fn main() !void {
             }
         };
         defer allocator.free(window_list);
+
         // Figure out the atom for our custom application ID property
         const custom_app_id_atom = try common.intern_atom(
             conn.sock,

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -204,7 +204,7 @@ pub fn main() !void {
                 {
                     var msg_buf: [x.get_property.len]u8 = undefined;
                     x.get_property.serialize(&msg_buf, .{
-                        .window_id = ids.window,
+                        .window_id = window_id,
                         .property = custom_app_id_atom,
                         .type = x.Atom.STRING,
                         .offset = 0,

--- a/src/screen_play/render.zig
+++ b/src/screen_play/render.zig
@@ -222,9 +222,10 @@ pub fn createResources(
             // Normally if we set this to `true`, this would be a dead-simple way to get
             // a border-less window without decorations. But we set this to `false` so
             // that it doesn't try to fight with us in our test environment to be on
-            // top. We should instead be setting window properties to hint that it's
-            // full screen to the window manager. And when there is no window manager
-            // we don't need to worry about setting the properties anyway.
+            // top. We instead be set window properties to hint that it's fullscreen to
+            // the window manager and stack it below the `aim_analyzer window if it
+            // exists. And when there is no window manager we don't need to worry about
+            // setting the properties anyway.
             .override_redirect = false,
             // .save_under = true,
             .event_mask = x.event.key_press | x.event.key_release | x.event.button_press | x.event.button_release | x.event.enter_window | x.event.leave_window | x.event.pointer_motion | x.event.keymap_state | x.event.exposure,

--- a/src/screen_play/render.zig
+++ b/src/screen_play/render.zig
@@ -328,8 +328,14 @@ pub fn createResources(
                 const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
                 const picture_formats = msg.getPictureFormats();
                 break :blk .{
-                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats, 24),
-                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats, 32),
+                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(
+                        picture_formats,
+                        24,
+                    ),
+                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(
+                        picture_formats,
+                        32,
+                    ),
                 };
             },
             else => |msg| {

--- a/src/screen_play/render.zig
+++ b/src/screen_play/render.zig
@@ -328,8 +328,8 @@ pub fn createResources(
                 const msg: *x.render.query_pict_formats.Reply = @ptrCast(msg_reply);
                 const picture_formats = msg.getPictureFormats();
                 break :blk .{
-                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 24),
-                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats[0..], 32),
+                    .matching_picture_format_24 = try common.findMatchingPictureFormatForDepth(picture_formats, 24),
+                    .matching_picture_format_32 = try common.findMatchingPictureFormatForDepth(picture_formats, 32),
                 };
             },
             else => |msg| {

--- a/src/x11/x11_common.zig
+++ b/src/x11/x11_common.zig
@@ -156,10 +156,10 @@ pub fn connect(allocator: std.mem.Allocator) !ConnectResult {
 
         // Try no authentication
         std.log.debug("trying no auth", .{});
-        var msg_buf: [x.connect_setup.getLen(0, 0)]u8 = undefined;
+        var message_buffer: [x.connect_setup.getLen(0, 0)]u8 = undefined;
         if (try connectSetup(
             sock,
-            &msg_buf,
+            &message_buffer,
             .{ .ptr = undefined, .len = 0 },
             .{ .ptr = undefined, .len = 0 },
         )) |reply_len| {
@@ -268,12 +268,12 @@ pub fn intern_atom(sock: std.os.socket_t, buffer: *x.ContiguousReadBuffer, compt
     const reader = common.SocketReader{ .context = sock };
 
     {
-        var msg_buf: [x.intern_atom.getLen(atom_name.len)]u8 = undefined;
-        x.intern_atom.serialize(&msg_buf, .{
+        var message_buffer: [x.intern_atom.getLen(atom_name.len)]u8 = undefined;
+        x.intern_atom.serialize(&message_buffer, .{
             .only_if_exists = false,
             .name = atom_name,
         });
-        try common.send(sock, msg_buf[0..]);
+        try common.send(sock, message_buffer[0..]);
     }
     const atom: x.Atom = blk: {
         _ = try x.readOneMsg(reader, @alignCast(buffer.nextReadBuffer()));


### PR DESCRIPTION
Resolve window stacking in tests (without relying on magic sleep delays)

 - Always stack the `aim_analyzer` window above any others
 - Stack the `screen_play` window below the `aim_analyzer` window if it exists

Requires:

 - https://github.com/marler8997/zigx/pull/16
 - https://github.com/marler8997/zigx/pull/15
 - https://github.com/marler8997/zigx/pull/17

### Todo

 - [x] Update to add fullscreen window properties
 - [x] Update to use `stack_mode` `below` with a `sibling` to stack the `screen_play` window below the `aim_analyzer` window


### Dev notes

```
Xephyr :99 -screen 1920x1080x24

DISPLAY=:99 zig build test --summary all -Dtest-filter="end-to-end"
```