### PR TITLE
Update Zig `build.zig` with better patterns

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,15 +15,6 @@ pub fn build(b: *std.Build) !void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "aim-analyzer",
-        // In this case the main source file is merely a path, however, in more
-        // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/main.zig" },
-        .target = target,
-        .optimize = optimize,
-    });
-
     // Other example of using zigx,
     // https://github.com/marler8997/image-viewer/blob/f189f2547890d61a1770327e105b01fc704f98c4/build.zig#L43-L44
     const zigx_dep = b.dependency("zigx", .{});
@@ -37,17 +28,18 @@ pub fn build(b: *std.Build) !void {
     inline for ([_]struct {
         name: []const u8,
         src: []const u8,
+        build_by_default: bool,
     }{
         // zig build run-main
-        .{ .name = "main", .src = "src/main.zig" },
+        .{ .name = "main", .src = "src/main.zig", .build_by_default = true },
         // zig build run-screen_play
-        .{ .name = "screen_play", .src = "src/main_screen_play.zig" },
+        .{ .name = "screen_play", .src = "src/main_screen_play.zig", .build_by_default = false },
     }) |exe_cfg| {
         const exe_name = exe_cfg.name;
         const exe_src = exe_cfg.src;
         const exe_build_desc = try std.fmt.allocPrint(
             b.allocator,
-            "Build the {s} example",
+            "Build {s}",
             .{exe_name},
         );
         const exe_run_stepname = try std.fmt.allocPrint(
@@ -57,78 +49,59 @@ pub fn build(b: *std.Build) !void {
         );
         const exe_run_stepdesc = try std.fmt.allocPrint(
             b.allocator,
-            "Run the {s} example",
+            "Run {s}",
             .{exe_name},
         );
-        const example_step = b.step(exe_name, exe_build_desc);
 
-        const example_exe = b.addExecutable(.{
+        const exe = b.addExecutable(.{
             .name = exe_name,
             .root_source_file = .{ .path = exe_src },
             .target = target,
             .optimize = optimize,
         });
         // Make the `zigx` module available to be imported via `@import("x")`
-        example_exe.addModule("x", zigx_dep.module("zigx"));
+        exe.addModule("x", zigx_dep.module("zigx"));
         // Make the `zigimg` module available to be imported via `@import("zigimg")`
-        example_exe.addModule("zigimg", zigimg_dep.module("zigimg"));
+        exe.addModule("zigimg", zigimg_dep.module("zigimg"));
 
-        // install the artifact - depending on the "example"
-        const example_build_step = b.addInstallArtifact(example_exe, .{});
+        // The `install_artifact` marks the intent for the executable to be installed
+        // into the standard location when the user invokes the "install" step.
+        const install_artifact = b.addInstallArtifact(exe, .{});
+        if (exe_cfg.build_by_default) {
+            // Install the artifact by default when the user runs `zig build` by itself.
+            //
+            // Equivalent to the second-half of `b.installArtifact(exe);` that "adds it
+            // to the dependencies of the top-level install step"
+            b.getInstallStep().dependOn(&install_artifact.step);
+        }
+
+        // This creates a build step. It will be visible in the `zig build --help` menu,
+        // and can be selected like this: `zig build xxx`
+        const build_step = b.step(exe_name, exe_build_desc);
+        build_step.dependOn(&install_artifact.step);
+        all_step.dependOn(&install_artifact.step);
 
         // This *creates* a Run step in the build graph, to be executed when another
         // step is evaluated that depends on it. The next line below will establish
         // such a dependency.
-        const example_run_cmd = b.addRunArtifact(example_exe);
+        const run_artifact = b.addRunArtifact(exe);
         // By making the run step depend on the install step, it will be run from the
         // installation directory rather than directly from within the cache directory.
         // This is not necessary, however, if the application depends on other installed
         // files, this ensures they will be present and in the expected location.
-        example_run_cmd.step.dependOn(&example_build_step.step);
-
+        run_artifact.step.dependOn(&install_artifact.step);
         // This allows the user to pass arguments to the application in the build
         // command itself, like this: `zig build run -- arg1 arg2 etc`
         if (b.args) |args| {
-            example_run_cmd.addArgs(args);
+            run_artifact.addArgs(args);
         }
 
         // This creates a build step. It will be visible in the `zig build --help` menu,
-        // and can be selected like this: `zig build run`
+        // and can be selected like this: `zig build run-xxx`
         // This will evaluate the `run` step rather than the default, which is "install".
-        const example_run_step = b.step(exe_run_stepname, exe_run_stepdesc);
-        example_run_step.dependOn(&example_run_cmd.step);
-
-        example_step.dependOn(&example_build_step.step);
-        all_step.dependOn(&example_build_step.step);
+        const run_step = b.step(exe_run_stepname, exe_run_stepdesc);
+        run_step.dependOn(&run_artifact.step);
     }
-
-    // This declares intent for the executable to be installed into the
-    // standard location when the user invokes the "install" step (the default
-    // step when running `zig build`).
-    b.installArtifact(exe);
-
-    // This *creates* a Run step in the build graph, to be executed when another
-    // step is evaluated that depends on it. The next line below will establish
-    // such a dependency.
-    const run_cmd = b.addRunArtifact(exe);
-
-    // By making the run step depend on the install step, it will be run from the
-    // installation directory rather than directly from within the cache directory.
-    // This is not necessary, however, if the application depends on other installed
-    // files, this ensures they will be present and in the expected location.
-    run_cmd.step.dependOn(b.getInstallStep());
-
-    // This allows the user to pass arguments to the application in the build
-    // command itself, like this: `zig build run -- arg1 arg2 etc`
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
-    // This creates a build step. It will be visible in the `zig build --help` menu,
-    // and can be selected like this: `zig build run`
-    // This will evaluate the `run` step rather than the default, which is "install".
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
 
     // Testing
     // ============================================


### PR DESCRIPTION
Update Zig `build.zig` with better patterns

Based on learnings from [`MadLittleMods/zig-x-compositing-manager` -> `build.zig`](https://github.com/MadLittleMods/zig-x-compositing-manager/blob/0d87174008a00978dbd470a61b5236b801d42879/build.zig)

### Dev notes

 - https://ziglang.org/learn/build-system/
 - https://ziggit.dev/t/build-system-tricks/3531
 - Packages, Modules, Dependencies - Zig Build System Basics (Zig SHOWTIME with Loris Cro), https://www.youtube.com/watch?v=jy7w_7JZYyw