### PR TITLE
Set `_NET_WM_PID` so we can find the window ID by the process ID

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const x = @import("x");
 const common = @import("x11/x11_common.zig");
 const x11_extension_utils = @import("x11/x11_extension_utils.zig");
@@ -171,62 +170,11 @@ const MainProgram = struct {
             // List any other windows we create from this process
             ids.window,
         }) |window_id| {
-            {
-                const wm_pid_atom = try common.intern_atom(
-                    conn.sock,
-                    &buffer,
-                    comptime x.Slice(u16, [*]const u8).initComptime("_NET_WM_PID"),
-                );
-
-                const pid: u32 = switch (builtin.os.tag) {
-                    .linux => blk: {
-                        const pid = std.os.linux.getpid();
-                        if (pid < 0) {
-                            std.log.err("Process ID (PID) unexpectedly negative (expected it to be positive) -> {d}", .{pid});
-                            return error.ProcessIdUnexpectedlyNegative;
-                        }
-
-                        break :blk @intCast(pid);
-                    },
-                    .windows => std.os.windows.kernel32.GetCurrentProcessId(),
-                    else => 0,
-                };
-
-                const pid_array = [_]u32{pid};
-                const change_property = x.change_property.withFormat(u32);
-                var message_buffer: [change_property.getLen(pid_array.len)]u8 = undefined;
-                change_property.serialize(&message_buffer, .{
-                    .mode = .replace,
-                    .window_id = window_id,
-                    .property = wm_pid_atom,
-                    .type = x.Atom.CARDINAL,
-                    .values = x.Slice(u16, [*]const u32){ .ptr = &pid_array, .len = pid_array.len },
-                });
-                try conn.send(message_buffer[0..]);
-            }
-            // "If _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be set."
-            // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
-            {
-                var host_name_buffer: [std.os.HOST_NAME_MAX]u8 = undefined;
-                // "While the ICCCM only requests that WM_CLIENT_MACHINE is set “ to a string
-                // that forms the name of the machine running the client as seen from the
-                // machine running the server” conformance to this specification requires that
-                // WM_CLIENT_MACHINE be set to the fully-qualified domain name of the client's
-                // host."
-                // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
-                const machine_name = try std.os.gethostname(&host_name_buffer);
-                const change_property = x.change_property.withFormat(u8);
-                var message_buffer = try allocator.alloc(u8, change_property.getLen(@intCast(machine_name.len)));
-                defer allocator.free(message_buffer);
-                change_property.serialize(message_buffer.ptr, .{
-                    .mode = .replace,
-                    .window_id = window_id,
-                    .property = x.Atom.WM_CLIENT_MACHINE,
-                    .type = x.Atom.STRING,
-                    .values = x.Slice(u16, [*]const u8){ .ptr = machine_name.ptr, .len = @intCast(machine_name.len) },
-                });
-                try conn.send(message_buffer[0..]);
-            }
+            try common.set_window_pid_properties(
+                conn.sock,
+                &buffer,
+                window_id,
+            );
         }
 
         // Set the window name

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const x = @import("x");
 const common = @import("x11/x11_common.zig");
 const x11_extension_utils = @import("x11/x11_extension_utils.zig");
@@ -164,6 +165,69 @@ const MainProgram = struct {
             depth,
             state,
         );
+
+        // Set the `_NET_WM_PID` atom so we can later find the window ID by the PID
+        for ([_]u32{
+            // List any other windows we create from this process
+            ids.window,
+        }) |window_id| {
+            {
+                const wm_pid_atom = try common.intern_atom(
+                    conn.sock,
+                    &buffer,
+                    comptime x.Slice(u16, [*]const u8).initComptime("_NET_WM_PID"),
+                );
+
+                const pid: u32 = switch (builtin.os.tag) {
+                    .linux => blk: {
+                        const pid = std.os.linux.getpid();
+                        if (pid < 0) {
+                            std.log.err("Process ID (PID) unexpectedly negative (expected it to be positive) -> {d}", .{pid});
+                            return error.ProcessIdUnexpectedlyNegative;
+                        }
+
+                        break :blk @intCast(pid);
+                    },
+                    .windows => std.os.windows.kernel32.GetCurrentProcessId(),
+                    else => 0,
+                };
+
+                const pid_array = [_]u32{pid};
+                const change_property = x.change_property.withFormat(u32);
+                var message_buffer: [change_property.getLen(pid_array.len)]u8 = undefined;
+                change_property.serialize(&message_buffer, .{
+                    .mode = .replace,
+                    .window_id = window_id,
+                    .property = wm_pid_atom,
+                    .type = x.Atom.CARDINAL,
+                    .values = x.Slice(u16, [*]const u32){ .ptr = &pid_array, .len = pid_array.len },
+                });
+                try conn.send(message_buffer[0..]);
+            }
+            // "If _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be set."
+            // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+            {
+                var host_name_buffer: [std.os.HOST_NAME_MAX]u8 = undefined;
+                // "While the ICCCM only requests that WM_CLIENT_MACHINE is set “ to a string
+                // that forms the name of the machine running the client as seen from the
+                // machine running the server” conformance to this specification requires that
+                // WM_CLIENT_MACHINE be set to the fully-qualified domain name of the client's
+                // host."
+                // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+                const machine_name = try std.os.gethostname(&host_name_buffer);
+                const change_property = x.change_property.withFormat(u8);
+                var message_buffer = try allocator.alloc(u8, change_property.getLen(@intCast(machine_name.len)));
+                defer allocator.free(message_buffer);
+                change_property.serialize(message_buffer.ptr, .{
+                    .mode = .replace,
+                    .window_id = window_id,
+                    .property = x.Atom.WM_CLIENT_MACHINE,
+                    .type = x.Atom.STRING,
+                    .values = x.Slice(u16, [*]const u8){ .ptr = machine_name.ptr, .len = @intCast(machine_name.len) },
+                });
+                try conn.send(message_buffer[0..]);
+            }
+        }
 
         // Set the window name
         {

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -170,62 +170,11 @@ pub fn main() !void {
         // List any other windows we create from this process
         ids.window,
     }) |window_id| {
-        {
-            const wm_pid_atom = try common.intern_atom(
-                conn.sock,
-                &buffer,
-                comptime x.Slice(u16, [*]const u8).initComptime("_NET_WM_PID"),
-            );
-
-            const pid: u32 = switch (builtin.os.tag) {
-                .linux => blk: {
-                    const pid = std.os.linux.getpid();
-                    if (pid < 0) {
-                        std.log.err("Process ID (PID) unexpectedly negative (expected it to be positive) -> {d}", .{pid});
-                        return error.ProcessIdUnexpectedlyNegative;
-                    }
-
-                    break :blk @intCast(pid);
-                },
-                .windows => std.os.windows.kernel32.GetCurrentProcessId(),
-                else => 0,
-            };
-
-            const pid_array = [_]u32{pid};
-            const change_property = x.change_property.withFormat(u32);
-            var message_buffer: [change_property.getLen(pid_array.len)]u8 = undefined;
-            change_property.serialize(&message_buffer, .{
-                .mode = .replace,
-                .window_id = window_id,
-                .property = wm_pid_atom,
-                .type = x.Atom.CARDINAL,
-                .values = x.Slice(u16, [*]const u32){ .ptr = &pid_array, .len = pid_array.len },
-            });
-            try conn.send(message_buffer[0..]);
-        }
-        // "If _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be set."
-        // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
-        {
-            var host_name_buffer: [std.os.HOST_NAME_MAX]u8 = undefined;
-            // "While the ICCCM only requests that WM_CLIENT_MACHINE is set “ to a string
-            // that forms the name of the machine running the client as seen from the
-            // machine running the server” conformance to this specification requires that
-            // WM_CLIENT_MACHINE be set to the fully-qualified domain name of the client's
-            // host."
-            // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
-            const machine_name = try std.os.gethostname(&host_name_buffer);
-            const change_property = x.change_property.withFormat(u8);
-            var message_buffer = try allocator.alloc(u8, change_property.getLen(@intCast(machine_name.len)));
-            defer allocator.free(message_buffer);
-            change_property.serialize(message_buffer.ptr, .{
-                .mode = .replace,
-                .window_id = window_id,
-                .property = x.Atom.WM_CLIENT_MACHINE,
-                .type = x.Atom.STRING,
-                .values = x.Slice(u16, [*]const u8){ .ptr = machine_name.ptr, .len = @intCast(machine_name.len) },
-            });
-            try conn.send(message_buffer[0..]);
-        }
+        try common.set_window_pid_properties(
+            conn.sock,
+            &buffer,
+            window_id,
+        );
     }
 
     // During tests, find the external `aim_analyzer` window so we can stack our window below it.

--- a/src/main_screen_play.zig
+++ b/src/main_screen_play.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assertions = @import("utils/assertions.zig");
 const assert = assertions.assert;
 const x = @import("x");
@@ -164,7 +165,70 @@ pub fn main() !void {
         &state,
     );
 
-    // During tests, find the `aim_analyzer` window so we can stack our window below it.
+    // Set the `_NET_WM_PID` atom so we can later find the window ID by the PID
+    for ([_]u32{
+        // List any other windows we create from this process
+        ids.window,
+    }) |window_id| {
+        {
+            const wm_pid_atom = try common.intern_atom(
+                conn.sock,
+                &buffer,
+                comptime x.Slice(u16, [*]const u8).initComptime("_NET_WM_PID"),
+            );
+
+            const pid: u32 = switch (builtin.os.tag) {
+                .linux => blk: {
+                    const pid = std.os.linux.getpid();
+                    if (pid < 0) {
+                        std.log.err("Process ID (PID) unexpectedly negative (expected it to be positive) -> {d}", .{pid});
+                        return error.ProcessIdUnexpectedlyNegative;
+                    }
+
+                    break :blk @intCast(pid);
+                },
+                .windows => std.os.windows.kernel32.GetCurrentProcessId(),
+                else => 0,
+            };
+
+            const pid_array = [_]u32{pid};
+            const change_property = x.change_property.withFormat(u32);
+            var message_buffer: [change_property.getLen(pid_array.len)]u8 = undefined;
+            change_property.serialize(&message_buffer, .{
+                .mode = .replace,
+                .window_id = window_id,
+                .property = wm_pid_atom,
+                .type = x.Atom.CARDINAL,
+                .values = x.Slice(u16, [*]const u32){ .ptr = &pid_array, .len = pid_array.len },
+            });
+            try conn.send(message_buffer[0..]);
+        }
+        // "If _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be set."
+        // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+        {
+            var host_name_buffer: [std.os.HOST_NAME_MAX]u8 = undefined;
+            // "While the ICCCM only requests that WM_CLIENT_MACHINE is set “ to a string
+            // that forms the name of the machine running the client as seen from the
+            // machine running the server” conformance to this specification requires that
+            // WM_CLIENT_MACHINE be set to the fully-qualified domain name of the client's
+            // host."
+            // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+            const machine_name = try std.os.gethostname(&host_name_buffer);
+            const change_property = x.change_property.withFormat(u8);
+            var message_buffer = try allocator.alloc(u8, change_property.getLen(@intCast(machine_name.len)));
+            defer allocator.free(message_buffer);
+            change_property.serialize(message_buffer.ptr, .{
+                .mode = .replace,
+                .window_id = window_id,
+                .property = x.Atom.WM_CLIENT_MACHINE,
+                .type = x.Atom.STRING,
+                .values = x.Slice(u16, [*]const u8){ .ptr = machine_name.ptr, .len = @intCast(machine_name.len) },
+            });
+            try conn.send(message_buffer[0..]);
+        }
+    }
+
+    // During tests, find the external `aim_analyzer` window so we can stack our window below it.
     {
         // First, list all the child windows of the root window
         {

--- a/src/x11/x11_common.zig
+++ b/src/x11/x11_common.zig
@@ -1,5 +1,6 @@
 // This file is pretty much just copied from the zigx repo
 const std = @import("std");
+const builtin = @import("builtin");
 const x = @import("x");
 const common = @This();
 
@@ -290,4 +291,68 @@ pub fn intern_atom(sock: std.os.socket_t, buffer: *x.ContiguousReadBuffer, compt
     };
 
     return atom;
+}
+
+/// Set the `_NET_WM_PID` atom on the given window so we can later find the window ID by
+/// the process ID (PID).
+///
+/// Also sets `WM_CLIENT_MACHINE` to the machine hostname to comply with the specs: "If
+/// _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be
+/// set." (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+pub fn set_window_pid_properties(sock: std.os.socket_t, buffer: *x.ContiguousReadBuffer, window_id: u32) !void {
+    {
+        const wm_pid_atom = try common.intern_atom(
+            sock,
+            buffer,
+            comptime x.Slice(u16, [*]const u8).initComptime("_NET_WM_PID"),
+        );
+
+        const pid: u32 = switch (builtin.os.tag) {
+            .linux => blk: {
+                const pid = std.os.linux.getpid();
+                if (pid < 0) {
+                    std.log.err("Process ID (PID) unexpectedly negative (expected it to be positive) -> {d}", .{pid});
+                    return error.ProcessIdUnexpectedlyNegative;
+                }
+
+                break :blk @intCast(pid);
+            },
+            .windows => std.os.windows.kernel32.GetCurrentProcessId(),
+            else => 0,
+        };
+
+        const pid_array = [_]u32{pid};
+        const change_property = x.change_property.withFormat(u32);
+        var message_buffer: [change_property.getLen(pid_array.len)]u8 = undefined;
+        change_property.serialize(&message_buffer, .{
+            .mode = .replace,
+            .window_id = window_id,
+            .property = wm_pid_atom,
+            .type = x.Atom.CARDINAL,
+            .values = x.Slice(u16, [*]const u32){ .ptr = &pid_array, .len = pid_array.len },
+        });
+        try common.send(sock, message_buffer[0..]);
+    }
+    // "If _NET_WM_PID is set, the ICCCM-specified property WM_CLIENT_MACHINE MUST also be set."
+    // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+    {
+        var host_name_buffer: [std.os.HOST_NAME_MAX]u8 = undefined;
+        // "While the ICCCM only requests that WM_CLIENT_MACHINE is set "to a string
+        // that forms the name of the machine running the client as seen from the
+        // machine running the server" conformance to this specification requires that
+        // WM_CLIENT_MACHINE be set to the fully-qualified domain name of the client's
+        // host."
+        // (https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14)
+        const machine_name = try std.os.gethostname(&host_name_buffer);
+        const change_property = x.change_property.withFormat(u8);
+        var message_buffer: [change_property.getLen(@intCast(std.os.HOST_NAME_MAX))]u8 = undefined;
+        change_property.serialize(&message_buffer, .{
+            .mode = .replace,
+            .window_id = window_id,
+            .property = x.Atom.WM_CLIENT_MACHINE,
+            .type = x.Atom.STRING,
+            .values = x.Slice(u16, [*]const u8){ .ptr = machine_name.ptr, .len = @intCast(machine_name.len) },
+        });
+        try common.send(sock, message_buffer[0..change_property.getLen(@intCast(machine_name.len))]);
+    }
 }


### PR DESCRIPTION
Set `_NET_WM_PID` so we can find the window ID by the process ID


### Dev notes

Based on https://github.com/MadLittleMods/zig-x-compositing-manager/blob/0d87174008a00978dbd470a61b5236b801d42879/src/main.zig#L335-L393